### PR TITLE
Allow user to use rank name as well as rank number in rank & role binding

### DIFF
--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -201,7 +201,7 @@ class DiscordBot {
                             }
 
                             binding.group = bindArgs[0];
-                            binding.rank = parseInt(rankUnparsed, 10);
+                            binding.rank = parseInt(rankUnparsed, 10) ? parseInt(rankUnparsed, 10) : rankUnparsed;
                             binding.role = bindArgs[2];
                         } else {
                             return msg.reply("Wrong number of arguments: needs 2 or 3");


### PR DESCRIPTION
binding.rank can now either be rank number or rank name.