### PR TITLE
Fix help command not working

### DIFF
--- a/src/commands/rover/HelpCommand.js
+++ b/src/commands/rover/HelpCommand.js
@@ -12,6 +12,6 @@ class HelpCommand extends Command {
 
     async fn(msg) {
         let commandGroup = this.client.registry.groups.get('rover');
-        msg.reply(commandGroup.commands.map(cmd => `**!${cmd.name}:** ${cmd.description}`).join('\n\n'));
+        msg.reply(commandGroup.commands.map(cmd => `**!${cmd.name}:** ${cmd.description}`).join('\n\n'), {split: true});
     }
 }

--- a/src/commands/rover/WhoisCommand.js
+++ b/src/commands/rover/WhoisCommand.js
@@ -9,7 +9,7 @@ class WhoisCommand extends Command {
             name: 'whois',
             aliases: ['roblox'],
             userPermissions: [],
-            description: "<person> Get a verified person's ROBLOX & profile link.",
+            description: "`<person>` Get a verified person's ROBLOX & profile link.",
             
             args: [
                 {


### PR DESCRIPTION
Fix 'invalid form body content' error when trying to use the help command.