### PR TITLE
Added millions support to user count

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ async function getNextActivity () {
   }
 }
 
-const numberAbbreviations = ['K', 'M', 'B' ,'T']
+const numberAbbreviations = ['K', 'M', 'B', 'T']
 request('https://verify.eryn.io/api/count')
   .then(count => {
     totalUsers = parseInt(count, 10).toFixed(1)

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ async function getNextActivity () {
   }
 }
 
-var numberAbbreviations = ['K', 'M', 'B' ,'T']
+const numberAbbreviations = ['K', 'M', 'B' ,'T']
 request('https://verify.eryn.io/api/count')
   .then(count => {
     totalUsers = parseInt(count, 10).toFixed(1)

--- a/src/index.js
+++ b/src/index.js
@@ -49,9 +49,21 @@ async function getNextActivity () {
   }
 }
 
+var numberAbbreviations = ["K","M","B","T"];
 request('https://verify.eryn.io/api/count')
   .then(count => {
-    totalUsers = (parseInt(count, 10) / 1000).toFixed(1) + 'K'
+    totalUsers = parseInt(count, 10).toFixed(1);
+
+    //Count how many times the place is shifted
+    var placeShift = 0;
+    while (totalUsers >= 1000) {
+      totalUsers = (totalUsers/1000).toFixed(1);
+      placeShift++;
+    }
+
+    if (placeShift > 0) {
+      totalUsers += numberAbbreviations[placeShift - 1];
+    };
   })
 
 setInterval(async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -49,21 +49,21 @@ async function getNextActivity () {
   }
 }
 
-var numberAbbreviations = ["K","M","B","T"];
+var numberAbbreviations = ['K','M','B','T']
 request('https://verify.eryn.io/api/count')
   .then(count => {
-    totalUsers = parseInt(count, 10).toFixed(1);
+    totalUsers = parseInt(count, 10).toFixed(1)
 
     //Count how many times the place is shifted
-    var placeShift = 0;
+    var placeShift = 0
     while (totalUsers >= 1000) {
-      totalUsers = (totalUsers/1000).toFixed(1);
-      placeShift++;
+      totalUsers = (totalUsers/1000).toFixed(1)
+      placeShift++
     }
 
     if (placeShift > 0) {
-      totalUsers += numberAbbreviations[placeShift - 1];
-    };
+      totalUsers += numberAbbreviations[placeShift - 1]
+    }
   })
 
 setInterval(async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -49,15 +49,15 @@ async function getNextActivity () {
   }
 }
 
-var numberAbbreviations = ['K','M','B','T']
+var numberAbbreviations = ['K', 'M', 'B' ,'T']
 request('https://verify.eryn.io/api/count')
   .then(count => {
     totalUsers = parseInt(count, 10).toFixed(1)
 
-    //Count how many times the place is shifted
-    var placeShift = 0
+    // Count how many times the place is shifted
+    let placeShift = 0
     while (totalUsers >= 1000) {
-      totalUsers = (totalUsers/1000).toFixed(1)
+      totalUsers = (totalUsers / 1000).toFixed(1)
       placeShift++
     }
 


### PR DESCRIPTION
Added support for millions, billions, and trillions to the user count.
Insignificant display change, but it was starting to bother me as it wasn't fixed. Previously, RoVer would display "Listening to 1043.4K users" as millions were not supported. Now, it displays "Listening to 1.0M users". Billions and trillions were also added, and although it's excessive, it's better safe than sorry.