### PR TITLE
Additional VirtualGroups

### DIFF
--- a/src/VirtualGroups.js
+++ b/src/VirtualGroups.js
@@ -60,7 +60,21 @@ module.exports = {
 
     return userProfile.groups.find(g => g.name === 'Roblox_Staff') != null
   },
+  
+  async CommunitySage (user) {
+    const userProfile = await getDevForumProfile(user)
+    if (!userProfile) return
 
+    return userProfile.groups.find(g => g.name === 'Community_Sage') != null
+  },
+  
+  async PostApproval (user) {
+    const userProfile = await getDevForumProfile(user)
+    if (!userProfile) return
+
+    return userProfile.groups.find(g => g.name === 'Post_Approval') != null
+  },
+  
   /**
    * Check if the given user is in the Roblox Dev Forum.
    *


### PR DESCRIPTION
The addition of two more virtual groups, Community Sage and Post Approval teams from the Developer Forums.

Users in these groups used to come under the Top Contributor VirtualGroup but due to the recent changes in structure, they were made separate to open up Top Contributor to public.