### PR TITLE
Remove ability to bind @everyone/@here

### DIFF
--- a/src/commands/rover/BindGroupCommand.js
+++ b/src/commands/rover/BindGroupCommand.js
@@ -44,6 +44,8 @@ class BindGroupCommand extends Command {
       )
       return
     }
+    
+    if (args.role.name === "@everyone" || role.name === "@here") return msg.reply('You are unable to bind this role.')
 
     binding.role = args.role.id
     binding.groups = []

--- a/src/commands/rover/NotVerifiedRoleCommand.js
+++ b/src/commands/rover/NotVerifiedRoleCommand.js
@@ -25,6 +25,7 @@ class NotVerifiedRoleCommand extends Command {
     if (this.server.ongoingSettingsUpdate) return msg.reply('Server settings are currently being saved - please try again in a few moments.')
     let role = args.role
     if (role) {
+      if (role.name === "@everyone" || role.name === "@here") return msg.reply('You are unable to use this role.')
       if (this.server.isRoleInUse(role.id)) {
         msg.reply(`That role is already in use. (verified role, not verified role, or from a group binding). Run \`${msg.guild.commandPrefix}bindings\` to see all role bindings.`)
       } else {

--- a/src/commands/rover/VerifiedRoleCommand.js
+++ b/src/commands/rover/VerifiedRoleCommand.js
@@ -25,6 +25,7 @@ class VerifiedRoleCommand extends Command {
     if (this.server.ongoingSettingsUpdate) return msg.reply('Server settings are currently being saved - please try again in a few moments.')
     let role = args.role
     if (role) {
+      if (role.name === "@everyone" || role.name === "@here") return msg.reply('You are unable to use this role.')
       if (this.server.isRoleInUse(role.id)) {
         msg.reply(`That role is already in use. (verified role, not verified role, or from a group binding). Run \`${msg.guild.commandPrefix}bindings\` to see all role bindings.`)
       } else {


### PR DESCRIPTION
Confusing error message would say that RoVer didn't have perms to add/remove roles to the user when @everyone or @here was bound.