### PR TITLE
Added 'DevForumRegular' VirtualGroup

### DIFF
--- a/src/VirtualGroups.js
+++ b/src/VirtualGroups.js
@@ -107,11 +107,11 @@ module.exports = {
     return module.exports.DevForumAccess(user, x => x === 1)
   },
 
-  async DevForumMember (user) {
+  async DevForumMember (user) { // old, left for compatibility
     return module.exports.DevForumAccess(user, x => x >= 2)
   },
 
-  async DevForumNewMember (user) { // old, left for compatibility
+  async DevForumNewMember (user) {
     return module.exports.DevForumAccess(user, x => x === 1)
   },
 

--- a/src/VirtualGroups.js
+++ b/src/VirtualGroups.js
@@ -111,8 +111,12 @@ module.exports = {
     return module.exports.DevForumAccess(user, x => x >= 2)
   },
 
-  async DevForumNewMember (user) {
+  async DevForumNewMember (user) { // old, left for compatibility
     return module.exports.DevForumAccess(user, x => x === 1)
+  },
+
+  async DevForumRegular (user) {
+    return module.exports.DevForumAccess(user, x => x >= 2)
   },
 
   /**


### PR DESCRIPTION
Added the new name for the full member rank of the Developer Forums as of February 2020.

**This does not rename `DevForumMember` despite the `New Member` rank being renamed `Member` due to compatibility issues.**