### PR TITLE
New VirtualGroup and changes to getDevForumProfile

### DIFF
--- a/src/VirtualGroups.js
+++ b/src/VirtualGroups.js
@@ -11,16 +11,16 @@ const request = require('request-promise')
  * Check if the given user is in the Roblox Dev Forum.
  *
  * @param {object} user The user data
- * @returns {object} The DebForum profile data
+ * @returns {object} The DevForum profile data
  */
 async function getDevForumProfile (user) {
-  const username = user.username
+  const userId = user.id
   let userProfile = await Cache.get(`bindings.${user.id}`, 'DevForumProfile')
 
   if (!userProfile) {
     try {
       const devForumData = await request({
-        uri: `https://devforum.roblox.com/users/${username}.json`,
+        uri: `https://devforum.roblox.com/u/by-external/${userId}.json`,
         json: true,
         simple: false
       })

--- a/src/VirtualGroups.js
+++ b/src/VirtualGroups.js
@@ -92,7 +92,9 @@ module.exports = {
       return true
     }
 
-    if (!userTrustLevel || !trustLevelCheck(userTrustLevel) || userProfile.suspended_till) {
+    // !userTrustLevel also returns true when it is 0, causing it to return false
+    // this is why we check it with == null, in case it is actually 0
+    if (userTrustLevel == null || !trustLevelCheck(userTrustLevel) || userProfile.suspended_till) {
       return false
     }
 

--- a/src/VirtualGroups.js
+++ b/src/VirtualGroups.js
@@ -110,6 +110,10 @@ module.exports = {
   async DevForumMember (user) { // old, left for compatibility
     return module.exports.DevForumAccess(user, x => x >= 2)
   },
+  
+  async DevForumVisitor (user) {
+    return module.exports.DevForumAccess(user, x => x === 0)
+  },
 
   async DevForumNewMember (user) {
     return module.exports.DevForumAccess(user, x => x === 1)

--- a/src/VirtualGroups.js
+++ b/src/VirtualGroups.js
@@ -112,7 +112,7 @@ module.exports = {
   async DevForumMember (user) { // old, left for compatibility
     return module.exports.DevForumAccess(user, x => x >= 2)
   },
-  
+
   async DevForumVisitor (user) {
     return module.exports.DevForumAccess(user, x => x === 0)
   },


### PR DESCRIPTION
This pull requests adds a new VirtualGroup, `DevForumVisitor`, which gives a role when the user has a DevForum account but is not a Member+.

I also changed `getDevForumProfile()` to use another endpoint on the DevForum that allows to retrieve the data via the user id. This fixes a lot of problems with people changing their name and losing their roles and not knowing how to get them back or what the problem is.