### PR TITLE
Provide owner ID to fix Unknown User error

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,23 +18,25 @@
 <h1 align="center"><a href="https://rover.link/#readme">Documentation can be found on the RoVer website</a></h1>
 
 ## Self-hosting instructions
+
 Self-hosting is recommended for advanced users only who are experienced with the Node.js ecosystem. Note that setup or code support will not be given for attempting to run your own instance of RoVer, modified or otherwise.
 
 1. To get RoVer ready to run locally, the first step is to clone this repository onto the machine you wish to run it on.
 2. **Node.js version 8.9.4 LTS or newer is recommended to run RoVer.**
 3. Use NPM to install the dependencies from the project folder: `npm install`
-4. Edit the file `src/data/client.json` and insert your [bot token](https://discordapp.com/developers/applications/me).
+4. Edit the file `src/data/client.json` and insert your [bot token](https://discordapp.com/developers/applications/me) and your Discord ID in the owner property.
 5. Start the bot from the project folder: `node ./src/index.js`
 6. You should set up a process manager like [PM2](http://pm2.keymetrics.io/) or forever.js to ensure that the bot remains online.
 
 ### Update Server
 
-The *Update Server* is an optional part of RoVer that can be enabled in `client.json`. It is an HTTP server that can listen for requests and globally update a member in all guilds that the bot is in, similar to if they ran `!verify` in every guild. This is used internally on the hosted version for when the user verifies on verify.eryn.io, but you could use it for whatever purpose you wish.
+The _Update Server_ is an optional part of RoVer that can be enabled in `client.json`. It is an HTTP server that can listen for requests and globally update a member in all guilds that the bot is in, similar to if they ran `!verify` in every guild. This is used internally on the hosted version for when the user verifies on verify.eryn.io, but you could use it for whatever purpose you wish.
 
 ### client.json options
 
 ```
-    "token"             : String. The bot token that is used to log in to your bot.
+    "token"             : String (required). The bot token that is used to log in to your bot.
+    "owner"             : String (required). The Discord ID of the bot's owner.
     "lockNicknames"     : Boolean. Default false. If true, the bot will run DiscordServer.verifyMember every time
                           they begin typing. This will quickly eat up API requests if you aren't careful. Mostly
                           used on the hosted version.
@@ -48,7 +50,6 @@ The *Update Server* is an optional part of RoVer that can be enabled in `client.
     "totalShards"       : Integer. Default auto. The number of shards to launch.
     "apiRequestMethod"  : String. Default 'sequential'. sequential' or 'burst'. Sequential executes all requests in the order
                           they are triggered, whereas burst runs multiple at a time, and doesn't guarantee a particular order.
-    "owner"             : String. Default "0". The Discord ID of the bot's owner.
     "commandPrefix"     : String. Default "!". The prefix for commands.
     "shardLifeTime"     : Integer. Number of seconds each shard will run before closing.
     "mainLifeTime"      : Integer. Number of seconds the main process will run before closing. (Need a process manager if you want it to relaunch)

--- a/src/data/client.json
+++ b/src/data/client.json
@@ -1,3 +1,4 @@
 {
-    "token": "Your bot token here"
+  "token": "Your bot token here",
+  "owner": "Your Discord ID"
 }


### PR DESCRIPTION
When locally or hosting an error will appear saying "Unknown User" if you don't provide the owner ID on client.json.