### PR TITLE
Added Warning for unauthorised use of RoVer Plus

### DIFF
--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -95,6 +95,7 @@ class DiscordBot {
             msg.reply('Sorry, the authorized users list is still being downloaded. This occurs when the bot has recently restarted. Please wait a few seconds and try again.')
           } else {
             msg.reply(`Sorry, this server isn't authorized to use RoVer Plus.${msg.member.hasPermission(['MANAGE_GUILD']) ? ' The server owner needs to donate at <https://www.patreon.com/erynlynn>, or you can invite the regular RoVer bot at <https://RoVer.link>.' : ''}`) // notify sender to donate only if they're an "admin"
+            console.log(`${msg.guild.owner.tag} is attemping to use RoVer Plus in their server without permission.`)
           }
 
           return 'not_premium'


### PR DESCRIPTION
This can be useful to help detect people using RoVer without permission if they obtained it without being Patreon Tier 2 or Tier 3.