### PR TITLE
Check server's verification level and act accordingly

### DIFF
--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -306,11 +306,8 @@ class DiscordBot {
 
     // Check the guild's verification level
     const securityLevel = member.guild.verificationLevel
-    try {
-      const messageIntro = `Welcome to ${member.guild.name}! This Discord server uses a Roblox account verification system to keep our community safe. Due to this server's security settings,`
-      if (securityLevel === 'MEDIUM' && (member.joinedTimestamp - member.user.createdTimestamp < 300000)) member.send(`${messageIntro} you must wait until your account is at least 5 minutes old to verify. Once the time is up, run \`${member.guild.commandPrefix}verify\` in the server to verify.`).catch(() => {})
-    }
-    catch (e) {}
+    const messageIntro = `Welcome to ${member.guild.name}! This Discord server uses a Roblox account verification system to keep our community safe. Due to this server's security settings,`
+    if (securityLevel === 'MEDIUM' && (member.joinedTimestamp - member.user.createdTimestamp < 300000)) member.send(`${messageIntro} you must wait until your account is at least 5 minutes old to verify. Once the time is up, run \`${member.guild.commandPrefix}verify\` in the server to verify.`).catch(() => {})
 
     const action = await discordMember.verify()
 

--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -310,12 +310,10 @@ class DiscordBot {
     if (securityLevel === 'MEDIUM' && (member.joinedTimestamp - member.user.createdTimestamp < 300000)) {
       member.send(`${securityMessageIntro} you must wait until your account is at least 5 minutes old to verify. Once the time is up, run \`${member.guild.commandPrefix}verify\` in the server to verify.`).catch(() => {})
       return
-    }
-    else if (securityLevel === 'HIGH') {
+    } else if (securityLevel === 'HIGH') {
       member.send(`${securityMessageIntro} you must wait 10 minutes to verify if you do not have a phone number linked to your Discord account. If you do have a linked phone number, you may immediately run \`${member.guild.commandPrefix}verify\` in the server.`).catch(() => {})
       return
-    }
-    else if (securityLevel === 'VERY_HIGH') {
+    } else if (securityLevel === 'VERY_HIGH') {
       member.send(`${securityMessageIntro} you must link your phone number to your Discord account. If you have already done so, you may run \`${member.guild.commandPrefix}verify\` in the server.`).catch(() => {})
       return
     }

--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -308,6 +308,7 @@ class DiscordBot {
     const securityLevel = member.guild.verificationLevel
     try {
       const messageIntro = `Welcome to ${member.guild.name}! This Discord server uses a Roblox account verification system to keep our community safe. Due to this server's security settings,`
+      if (securityLevel === 'MEDIUM' && (member.joinedTimestamp - member.user.createdTimestamp < 300000)) member.send(`${messageIntro} you must wait until your account is at least 5 minutes old to verify. Once the time is up, run \`${member.guild.commandPrefix}verify\` in the server to verify.`).catch(() => {})
     }
     catch (e) {}
 

--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -308,7 +308,10 @@ class DiscordBot {
     const securityLevel = member.guild.verificationLevel
     const messageIntro = `Welcome to ${member.guild.name}! This Discord server uses a Roblox account verification system to keep our community safe. Due to this server's security settings,`
     if (securityLevel === 'MEDIUM' && (member.joinedTimestamp - member.user.createdTimestamp < 300000)) member.send(`${messageIntro} you must wait until your account is at least 5 minutes old to verify. Once the time is up, run \`${member.guild.commandPrefix}verify\` in the server to verify.`).catch(() => {})
-
+    else if (securityLevel === 'HIGH') {
+      member.send(`${messageIntro} you must wait 10 minutes to verify if you do not have a phone number linked to your Discord account. If you do have a linked phone number, you may immediately run \`${member.guild.commandPrefix}verify\` in the server.`).catch(() => {})
+      return
+    }
     const action = await discordMember.verify()
 
     try {

--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -306,14 +306,17 @@ class DiscordBot {
 
     // Check the guild's verification level
     const securityLevel = member.guild.verificationLevel
-    const messageIntro = `Welcome to ${member.guild.name}! This Discord server uses a Roblox account verification system to keep our community safe. Due to this server's security settings,`
-    if (securityLevel === 'MEDIUM' && (member.joinedTimestamp - member.user.createdTimestamp < 300000)) member.send(`${messageIntro} you must wait until your account is at least 5 minutes old to verify. Once the time is up, run \`${member.guild.commandPrefix}verify\` in the server to verify.`).catch(() => {})
+    const securityMessageIntro = `Welcome to ${member.guild.name}! This Discord server uses a Roblox account verification system to keep our community safe. Due to this server's security settings,`
+    if (securityLevel === 'MEDIUM' && (member.joinedTimestamp - member.user.createdTimestamp < 300000)) {
+      member.send(`${securityMessageIntro} you must wait until your account is at least 5 minutes old to verify. Once the time is up, run \`${member.guild.commandPrefix}verify\` in the server to verify.`).catch(() => {})
+      return
+    }
     else if (securityLevel === 'HIGH') {
-      member.send(`${messageIntro} you must wait 10 minutes to verify if you do not have a phone number linked to your Discord account. If you do have a linked phone number, you may immediately run \`${member.guild.commandPrefix}verify\` in the server.`).catch(() => {})
+      member.send(`${securityMessageIntro} you must wait 10 minutes to verify if you do not have a phone number linked to your Discord account. If you do have a linked phone number, you may immediately run \`${member.guild.commandPrefix}verify\` in the server.`).catch(() => {})
       return
     }
     else if (securityLevel === 'VERY_HIGH') {
-      member.send(`${messageIntro} you must link your phone number to your Discord account. If you have already done so, you may run \`${member.guild.commandPrefix}verify\` in the server.`).catch(() => {})
+      member.send(`${securityMessageIntro} you must link your phone number to your Discord account. If you have already done so, you may run \`${member.guild.commandPrefix}verify\` in the server.`).catch(() => {})
       return
     }
     const action = await discordMember.verify()

--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -312,6 +312,10 @@ class DiscordBot {
       member.send(`${messageIntro} you must wait 10 minutes to verify if you do not have a phone number linked to your Discord account. If you do have a linked phone number, you may immediately run \`${member.guild.commandPrefix}verify\` in the server.`).catch(() => {})
       return
     }
+    else if (securityLevel === 'VERY_HIGH') {
+      member.send(`${messageIntro} you must link your phone number to your Discord account. If you have already done so, you may run \`${member.guild.commandPrefix}verify\` in the server.`).catch(() => {})
+      return
+    }
     const action = await discordMember.verify()
 
     try {

--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -303,6 +303,14 @@ class DiscordBot {
 
     const discordMember = await server.getMember(member.id)
     if (!member) return
+
+    // Check the guild's verification level
+    const securityLevel = member.guild.verificationLevel
+    try {
+      const messageIntro = `Welcome to ${member.guild.name}! This Discord server uses a Roblox account verification system to keep our community safe. Due to this server's security settings,`
+    }
+    catch (e) {}
+
     const action = await discordMember.verify()
 
     try {


### PR DESCRIPTION
RoVer should not automatically verify members on join if the server has a set verification level of high or very high, if it's medium then compare the member's joinedTimestamp and user.createdTimestamp, and autoverify if the account was created more than 5 minutes ago.