### PR TITLE
Fix for update server with Discord.js 12

### DIFF
--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -363,7 +363,7 @@ class DiscordBot {
     // Iterate through all of the guilds the bot is in.
     for (const guildId of guilds) {
       try {
-        if (!this.bot.guilds.has(guildId)) continue
+        if (!this.bot.guilds.cache.has(guildId)) continue
 
         const guild = this.bot.guilds.resolve(guildId)
         const server = await this.getServer(guild.id)


### PR DESCRIPTION
Discord.js 12 requires you use cache. When checking the bot's guilds, without cache the try request will stop which will prevent the update server from actually updating the user.