### PR TITLE
Mistyped variable causing whois command to break

### DIFF
--- a/src/commands/rover/WhoisCommand.js
+++ b/src/commands/rover/WhoisCommand.js
@@ -144,7 +144,7 @@ class WhoisCommand extends Command {
         if (pastNames !== 'Unknown') {
           embed.fields.push({
             name: 'Past Usernames',
-            value: pastName,
+            value: pastNames,
             inline: true
           })
         }


### PR DESCRIPTION
Embed data read the pastName instead of pastNames variable, which was undefined. Whois command did not work as such.