### PR TITLE
Use api endpoints instead of downloading profile page

### DIFF
--- a/src/commands/rover/WhoisCommand.js
+++ b/src/commands/rover/WhoisCommand.js
@@ -85,11 +85,11 @@ class WhoisCommand extends Command {
         let pastNames = ''
         try {
           const pastNamesData = await request({
-            uri: `https://users.roblox.com/v1/${data.robloxId}/username-history?limit=50&sortOrder=Desc`,
+            uri: `https://users.roblox.com/v1/users/${data.robloxId}/username-history?limit=50&sortOrder=Desc`,
             json: true,
             simple: false
           })
-          pastNamesData.data.forEach(name => pastNames += `, ${name}`)
+          pastNamesData.data.forEach(oldname => pastNames += `, ${oldname.name}`)
           if (pastNames) pastNames = pastNames.replace(', ', '')
         } catch (e) {}
 

--- a/src/commands/rover/WhoisCommand.js
+++ b/src/commands/rover/WhoisCommand.js
@@ -148,7 +148,7 @@ class WhoisCommand extends Command {
         }
 
         // Edit so past names don't show unless you actually have some!
-        if (pastNames) {
+        if (pastNames && pastNames !== []) {
           embed.fields.push({
             name: 'Past Usernames',
             value: pastNames,


### PR DESCRIPTION
Roblox appears to have blocked RoVer from downloading profile pages entirely, as of now we should start fetching the data from their api endpoints.