### PR TITLE
Adding automatic help and diagnostics

### DIFF
--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -104,7 +104,7 @@ class DiscordBot {
           if (this.authorizedOwners.length === 0) {
             msg.reply('Sorry, the authorized users list is still being downloaded. This occurs when the bot has recently restarted. Please wait a few seconds and try again.')
           } else {
-            msg.reply(`Sorry, this server isn't authorized to use RoVer Plus.${msg.member.hasPermission(['MANAGE_GUILD']) ? ' The server owner needs to donate at <https://www.patreon.com/erynlynn>, or you can invite the regular RoVer bot at <https://RoVer.link>.' : ''} If you are a patron encountering this issue, try running '!transferplus ${msg.guild.ownerID}'`) // notify sender to donate only if they're an "admin"
+            msg.reply(`Sorry, this server isn't authorized to use RoVer Plus.${msg.member.hasPermission(['MANAGE_GUILD']) ? ' The server owner needs to donate at <https://www.patreon.com/erynlynn>, or you can invite the regular RoVer bot at <https://RoVer.link>.' : ''} If you are a patron encountering this issue, try running '${this.bot.commandPrefix}transferplus ${msg.guild.ownerID}'`) // notify sender to donate only if they're an "admin"
           }
 
           return 'not_premium'

--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -104,7 +104,7 @@ class DiscordBot {
           if (this.authorizedOwners.length === 0) {
             msg.reply('Sorry, the authorized users list is still being downloaded. This occurs when the bot has recently restarted. Please wait a few seconds and try again.')
           } else {
-            msg.reply(`Sorry, this server isn't authorized to use RoVer Plus.${msg.member.hasPermission(['MANAGE_GUILD']) ? ' The server owner needs to donate at <https://www.patreon.com/erynlynn>, or you can invite the regular RoVer bot at <https://RoVer.link>.' : ''}`) // notify sender to donate only if they're an "admin"
+            msg.reply(`Sorry, this server isn't authorized to use RoVer Plus.${msg.member.hasPermission(['MANAGE_GUILD']) ? ' The server owner needs to donate at <https://www.patreon.com/erynlynn>, or you can invite the regular RoVer bot at <https://RoVer.link>.' : ''} If you are a patron encountering this issue, try running '!transferplus ${msg.member.id}'`) // notify sender to donate only if they're an "admin"
           }
 
           return 'not_premium'

--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -104,7 +104,7 @@ class DiscordBot {
           if (this.authorizedOwners.length === 0) {
             msg.reply('Sorry, the authorized users list is still being downloaded. This occurs when the bot has recently restarted. Please wait a few seconds and try again.')
           } else {
-            msg.reply(`Sorry, this server isn't authorized to use RoVer Plus.${msg.member.hasPermission(['MANAGE_GUILD']) ? ' The server owner needs to donate at <https://www.patreon.com/erynlynn>, or you can invite the regular RoVer bot at <https://RoVer.link>.' : ''} If you are a patron encountering this issue, try running '!transferplus ${msg.member.id}'`) // notify sender to donate only if they're an "admin"
+            msg.reply(`Sorry, this server isn't authorized to use RoVer Plus.${msg.member.hasPermission(['MANAGE_GUILD']) ? ' The server owner needs to donate at <https://www.patreon.com/erynlynn>, or you can invite the regular RoVer bot at <https://RoVer.link>.' : ''} If you are a patron encountering this issue, try running '!transferplus ${msg.guild.ownerID}'`) // notify sender to donate only if they're an "admin"
           }
 
           return 'not_premium'

--- a/src/commands/rover/BindGroupCommand.js
+++ b/src/commands/rover/BindGroupCommand.js
@@ -47,6 +47,8 @@ class BindGroupCommand extends Command {
 
     if (args.role.name === '@everyone' || args.role.name === '@here') return msg.reply('You are unable to bind this role.')
 
+    if (this.server.server.me.roles.highest.comparePositionTo(args.role) < 0) return msg.reply(':no_entry_sign: You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
+    
     binding.role = args.role.id
     binding.groups = []
 

--- a/src/commands/rover/BindGroupCommand.js
+++ b/src/commands/rover/BindGroupCommand.js
@@ -47,7 +47,7 @@ class BindGroupCommand extends Command {
 
     if (args.role.name === '@everyone' || args.role.name === '@here') return msg.reply('You are unable to bind this role.')
 
-    if (this.server.server.me.roles.highest.comparePositionTo(args.role) < 0) return msg.reply(':no_entry_sign: You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
+    if (this.server.server.me.roles.highest.comparePositionTo(args.role) < 0) return msg.reply('You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
     
     binding.role = args.role.id
     binding.groups = []

--- a/src/commands/rover/JoinMessageCommand.js
+++ b/src/commands/rover/JoinMessageCommand.js
@@ -7,7 +7,7 @@ class JoinMessageCommand extends Command {
       name: 'joindm',
       properName: 'JoinDM',
       aliases: ['roverjoindm'],
-      description: '`<on|off>` Set whether or not new users will be automatically direct messaged when joining this server. Default on. (This also effects whether or not users are automatically verified on joining.)',
+      description: '`<on|off>` Set whether or not new users will be automatically direct messaged when joining this server. Default on. (This also affects whether or not users are automatically verified on joining.)',
 
       args: [
         {

--- a/src/commands/rover/JoinMessageCommand.js
+++ b/src/commands/rover/JoinMessageCommand.js
@@ -7,7 +7,7 @@ class JoinMessageCommand extends Command {
       name: 'joindm',
       properName: 'JoinDM',
       aliases: ['roverjoindm'],
-      description: '`<on|off>` Set whether or not new users will be automatically direct messaged when joining this server. Default on',
+      description: '`<on|off>` Set whether or not new users will be automatically direct messaged when joining this server. Default on. (This also effects whether or not users are automatically verified on joining.)',
 
       args: [
         {

--- a/src/commands/rover/NotVerifiedRoleCommand.js
+++ b/src/commands/rover/NotVerifiedRoleCommand.js
@@ -26,6 +26,7 @@ class NotVerifiedRoleCommand extends Command {
     const role = args.role
     if (role) {
       if (role.name === '@everyone' || role.name === '@here') return msg.reply('You are unable to use this role.')
+      if (this.server.server.me.roles.highest.comparePositionTo(role) < 0) return msg.reply(':no_entry_sign: You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
       if (this.server.isRoleInUse(role.id)) {
         msg.reply(`That role is already in use. (verified role, not verified role, or from a group binding). Run \`${msg.guild.commandPrefix}bindings\` to see all role bindings.`)
       } else {

--- a/src/commands/rover/NotVerifiedRoleCommand.js
+++ b/src/commands/rover/NotVerifiedRoleCommand.js
@@ -26,7 +26,7 @@ class NotVerifiedRoleCommand extends Command {
     const role = args.role
     if (role) {
       if (role.name === '@everyone' || role.name === '@here') return msg.reply('You are unable to use this role.')
-      if (this.server.server.me.roles.highest.comparePositionTo(role) < 0) return msg.reply(':no_entry_sign: You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
+      if (this.server.server.me.roles.highest.comparePositionTo(role) < 0) return msg.reply('You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
       if (this.server.isRoleInUse(role.id)) {
         msg.reply(`That role is already in use. (verified role, not verified role, or from a group binding). Run \`${msg.guild.commandPrefix}bindings\` to see all role bindings.`)
       } else {

--- a/src/commands/rover/VerifiedRoleCommand.js
+++ b/src/commands/rover/VerifiedRoleCommand.js
@@ -26,7 +26,7 @@ class VerifiedRoleCommand extends Command {
     const role = args.role
     if (role) {
       if (role.name === '@everyone' || role.name === '@here') return msg.reply('You are unable to use this role.')
-      if (this.server.server.me.roles.highest.comparePositionTo(role) < 0) return msg.reply(':no_entry_sign: You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
+      if (this.server.server.me.roles.highest.comparePositionTo(role) < 0) return msg.reply('You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
       if (this.server.isRoleInUse(role.id)) {
         msg.reply(`That role is already in use. (verified role, not verified role, or from a group binding). Run \`${msg.guild.commandPrefix}bindings\` to see all role bindings.`)
       } else {

--- a/src/commands/rover/VerifiedRoleCommand.js
+++ b/src/commands/rover/VerifiedRoleCommand.js
@@ -26,6 +26,7 @@ class VerifiedRoleCommand extends Command {
     const role = args.role
     if (role) {
       if (role.name === '@everyone' || role.name === '@here') return msg.reply('You are unable to use this role.')
+      if (this.server.server.me.roles.highest.comparePositionTo(role) < 0) return msg.reply(':no_entry_sign: You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
       if (this.server.isRoleInUse(role.id)) {
         msg.reply(`That role is already in use. (verified role, not verified role, or from a group binding). Run \`${msg.guild.commandPrefix}bindings\` to see all role bindings.`)
       } else {


### PR DESCRIPTION
Adds:
- Checks to see if a given role is above RoVer when binding and cancels the bind until RoVer is placed above that role.
    - This includes Verifiedrole and Unverifiedrole
- Additional help information for Patrons using RoVer Plus in their server, letting them know to try <prefix>transferplus
- Additional help information for `joindm` stating that disabling it also turns of automatic verification on joining.

Resolves #298