### PR TITLE
Fetch bot member in guild when .me is null

### DIFF
--- a/src/commands/Command.js
+++ b/src/commands/Command.js
@@ -21,6 +21,9 @@ class Command extends Commando.Command {
 
   async run (msg, args, pattern) {
     this.server = msg.guild && await this.discordBot.getServer(msg.guild.id)
+    this.me = msg.guild.me
+    // Fetch the bot member in the case that .me is null
+    if (!this.me) this.me = await msg.guild.members.fetch(msg.client.user.id)
     return this.fn(msg, args, pattern)
   }
 }

--- a/src/commands/rover/BindGroupCommand.js
+++ b/src/commands/rover/BindGroupCommand.js
@@ -47,8 +47,8 @@ class BindGroupCommand extends Command {
 
     if (args.role.name === '@everyone' || args.role.name === '@here') return msg.reply('You are unable to bind this role.')
 
-    if (this.server.server.me.roles.highest.comparePositionTo(args.role) < 0) return msg.reply('You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
-    
+    if (this.me.roles.highest.comparePositionTo(args.role) < 0) return msg.reply('You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
+
     binding.role = args.role.id
     binding.groups = []
 

--- a/src/commands/rover/NotVerifiedRoleCommand.js
+++ b/src/commands/rover/NotVerifiedRoleCommand.js
@@ -26,9 +26,7 @@ class NotVerifiedRoleCommand extends Command {
     const role = args.role
     if (role) {
       if (role.name === '@everyone' || role.name === '@here') return msg.reply('You are unable to use this role.')
-      let botmember = this.server.server.me
-      if (!botmember) botmember = await this.server.server.members.fetch(msg.client.user.id)
-      if (botmember.roles.highest.comparePositionTo(role) < 0) return msg.reply('You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
+      if (this.me.roles.highest.comparePositionTo(role) < 0) return msg.reply('You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
       if (this.server.isRoleInUse(role.id)) {
         msg.reply(`That role is already in use. (verified role, not verified role, or from a group binding). Run \`${msg.guild.commandPrefix}bindings\` to see all role bindings.`)
       } else {

--- a/src/commands/rover/NotVerifiedRoleCommand.js
+++ b/src/commands/rover/NotVerifiedRoleCommand.js
@@ -26,7 +26,9 @@ class NotVerifiedRoleCommand extends Command {
     const role = args.role
     if (role) {
       if (role.name === '@everyone' || role.name === '@here') return msg.reply('You are unable to use this role.')
-      if (this.server.server.me.roles.highest.comparePositionTo(role) < 0) return msg.reply('You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
+      let botmember = this.server.server.me
+      if (!botmember) botmember = await this.server.server.members.fetch(msg.client.user.id)
+      if (botmember.roles.highest.comparePositionTo(role) < 0) return msg.reply('You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
       if (this.server.isRoleInUse(role.id)) {
         msg.reply(`That role is already in use. (verified role, not verified role, or from a group binding). Run \`${msg.guild.commandPrefix}bindings\` to see all role bindings.`)
       } else {

--- a/src/commands/rover/VerifiedRoleCommand.js
+++ b/src/commands/rover/VerifiedRoleCommand.js
@@ -28,7 +28,7 @@ class VerifiedRoleCommand extends Command {
       if (role.name === '@everyone' || role.name === '@here') return msg.reply('You are unable to use this role.')
       let botmember = this.server.server.me
       if (!botmember) botmember = this.server.server.members.fetch(msg.client.user.id)
-      if (this.server.server.me.roles.highest.comparePositionTo(role) < 0) return msg.reply('You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
+      if (botmember.roles.highest.comparePositionTo(role) < 0) return msg.reply('You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
       if (this.server.isRoleInUse(role.id)) {
         msg.reply(`That role is already in use. (verified role, not verified role, or from a group binding). Run \`${msg.guild.commandPrefix}bindings\` to see all role bindings.`)
       } else {

--- a/src/commands/rover/VerifiedRoleCommand.js
+++ b/src/commands/rover/VerifiedRoleCommand.js
@@ -26,9 +26,7 @@ class VerifiedRoleCommand extends Command {
     const role = args.role
     if (role) {
       if (role.name === '@everyone' || role.name === '@here') return msg.reply('You are unable to use this role.')
-      let botmember = this.server.server.me
-      if (!botmember) botmember = await this.server.server.members.fetch(msg.client.user.id)
-      if (botmember.roles.highest.comparePositionTo(role) < 0) return msg.reply('You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
+      if (this.me.roles.highest.comparePositionTo(role) < 0) return msg.reply('You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
       if (this.server.isRoleInUse(role.id)) {
         msg.reply(`That role is already in use. (verified role, not verified role, or from a group binding). Run \`${msg.guild.commandPrefix}bindings\` to see all role bindings.`)
       } else {

--- a/src/commands/rover/VerifiedRoleCommand.js
+++ b/src/commands/rover/VerifiedRoleCommand.js
@@ -26,6 +26,8 @@ class VerifiedRoleCommand extends Command {
     const role = args.role
     if (role) {
       if (role.name === '@everyone' || role.name === '@here') return msg.reply('You are unable to use this role.')
+      let botmember = this.server.server.me
+      if (!botmember) botmember = this.server.server.members.fetch(msg.client.user.id)
       if (this.server.server.me.roles.highest.comparePositionTo(role) < 0) return msg.reply('You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
       if (this.server.isRoleInUse(role.id)) {
         msg.reply(`That role is already in use. (verified role, not verified role, or from a group binding). Run \`${msg.guild.commandPrefix}bindings\` to see all role bindings.`)

--- a/src/commands/rover/VerifiedRoleCommand.js
+++ b/src/commands/rover/VerifiedRoleCommand.js
@@ -27,7 +27,7 @@ class VerifiedRoleCommand extends Command {
     if (role) {
       if (role.name === '@everyone' || role.name === '@here') return msg.reply('You are unable to use this role.')
       let botmember = this.server.server.me
-      if (!botmember) botmember = this.server.server.members.fetch(msg.client.user.id)
+      if (!botmember) botmember = await this.server.server.members.fetch(msg.client.user.id)
       if (botmember.roles.highest.comparePositionTo(role) < 0) return msg.reply('You have attempted to bind a role above the RoVer role, please move `RoVer` up in your role list and try again.')
       if (this.server.isRoleInUse(role.id)) {
         msg.reply(`That role is already in use. (verified role, not verified role, or from a group binding). Run \`${msg.guild.commandPrefix}bindings\` to see all role bindings.`)


### PR DESCRIPTION
Currently we've been seeing the verifiedrole command failing in some servers when .me is null, the notverifiedrole command was fixed as well in case that comes up.