### PR TITLE
Allow remote restarting of shard

### DIFF
--- a/src/commands/rover/RestartCommand.js
+++ b/src/commands/rover/RestartCommand.js
@@ -8,7 +8,16 @@ class RestartCommand extends Command {
       name: 'restart',
       properName: 'Restart',
       description: 'Restarts bot process',
-      userPermissions: []
+      userPermissions: [],
+      args: [
+        {
+          key: 'server',
+          label: 'server',
+          prompt: 'Server ID?',
+          type: 'string',
+          default: false
+        }
+      ]
     })
   }
 
@@ -16,8 +25,17 @@ class RestartCommand extends Command {
     return this.client.isOwner(msg.author) || (Accolades[msg.author.id] && Accolades[msg.author.id].match('Support Staff'))
   }
 
-  async fn (msg) {
-    await msg.reply('Restarting...')
-    process.exit()
+  async fn (msg, args) {
+    if (!args.server) {
+      await msg.reply('Restarting...')
+      process.exit()
+    }
+    const shard = msg.client.shard.shardIDForGuildID(msg.guild.id, msg.client.shard.count).catch(() => {
+      msg.reply('An invalid server id was given!')
+    })
+    // Zero is falsy so we don't want that to prevent restarts from working
+    if (!shard && shard !== 0) return
+    await msg.reply(`Restarting shard ${shard}!`)
+    msg.client.shard.broadcastEval('process.exit()', shard)
   }
 }


### PR DESCRIPTION
The current version of the restart command only allows for restarting the current shard, this version will allow supplying a server id, which will be used to find the correct shard and restart it.