### PR TITLE
Clarify UnverifyCommand

### DIFF
--- a/src/commands/rover/UnverifyCommand.js
+++ b/src/commands/rover/UnverifyCommand.js
@@ -6,13 +6,14 @@ class UnverifyCommand extends Command {
     super(client, {
       name: 'unverify',
       properName: 'Unverify',
+      description: 'Displays instructions on how to unverify',
       aliases: ['unlink'],
       userPermissions: []
     })
   }
 
   async fn (msg) {
-    msg.author.send('To unverify, please contact a moderator or above at our support server: https://discord.gg/7yfwrat').then(() => {
+    msg.author.send('Before we get started, you do **not** need to be unverified to verify as a new account, to reverify, head to https://verify.eryn.io/ and verify with the new account. \n\nTo unverify, you need to head to our support server at https://discord.gg/7yfwrat and ask one of the moderators to handle your unverification.').then(() => {
       msg.reply('Sent you a DM with information.')
     }).catch(() => {
       msg.reply('I can\'t seem to message you - please make sure your DMs are enabled!')


### PR DESCRIPTION
- Fix UnverifyCommand.js not having a command description definition (crashes on run without it)
- Add Code's request to clarify that you don't need to unverify to reverify.