### PR TITLE
Cache blocklisted users on start instead of fetching once for each shard (take 2)

### DIFF
--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -164,23 +164,6 @@ class DiscordBot {
     })
   }
 
-  async updateBlacklist () {
-    if (!config.banServer) {
-      return false
-    }
-
-    const response = await request(`https://discord.com/api/v6/guilds/${config.banServer}/bans`, {
-      json: true,
-      headers: {
-        Authorization: `Bot ${config.token}`
-      }
-    })
-
-    response.forEach(ban => {
-      this.blacklist[ban.user.id] = true
-    })
-  }
-
   async updatePatrons (page, newAuthorizedOwners) {
     if (!page) {
       newAuthorizedOwners = []

--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -152,12 +152,7 @@ class DiscordBot {
       return false
     }
 
-    const response = await request(`https://discord.com/api/v6/guilds/${config.banServer}/bans`, {
-      json: true,
-      headers: {
-        Authorization: `Bot ${config.token}`
-      }
-    })
+    const response = await global.Cache.get('blacklists', 'data')
 
     response.forEach(ban => {
       this.blacklist[ban.user.id] = true

--- a/src/GlobalCache.js
+++ b/src/GlobalCache.js
@@ -126,6 +126,17 @@ class GlobalCache {
       key: message.key
     })
   }
+  
+  /**
+   * Takes an array of ban objects
+   * @param {Array} bans The array of ban objects
+   * @memberof GlobalCache
+   */
+  setBlacklist (blacklists) {
+    const collection = this.getCollection('blacklists')
+    collection.data = blacklists
+    collection.created = Date.now()
+  }
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -21,10 +21,23 @@ shardingManager.on('shardCreate', shard => {
   console.log(`Launching shard ${shard.id + 1}/${shardingManager.totalShards}`)
 })
 
-shardingManager.spawn(config.totalShards || 'auto', 8000, -1)
-
 // Instantiate a GlobalCache, which will cache information from the shards.
 global.GlobalCache = new GlobalCache(shardingManager)
+
+;(async () => {
+  if (config.banServer) {
+    const banData = await request(`https://discord.com/api/v9/guilds/${config.banServer}/bans`, {
+      headers: {
+        authorization: `Bot ${config.token}`
+      },
+      json: true,
+      resolveWithFullResponse: true,
+      simple: false
+    }).catch(e => console.error(e))
+    if (res && res.statusCode === 200) global.GlobalCache.setBlacklist(res.body)
+  }
+  await shardingManager.spawn(config.totalShards || 'auto', 8000, -1)
+})()
 
 // Set bot status messages
 let currentActivity = 0


### PR DESCRIPTION
A redo of #324 since the commit history got incredibly polluted.

Essentially the blocklist information will be fetched before any of the shards are spawned and placed into the GlobalCache via a special method that doesn't require a shard object to be passed, where it will be read from by each shard.