### PR TITLE
Add direct messages intent

### DIFF
--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -30,8 +30,6 @@ class DiscordBot {
    */
   initialize () {
     this.bot = new Discord.Client({
-      apiRequestMethod: config.apiRequestMethod || 'sequential',
-      disabledEvents: ['TYPING_START', 'VOICE_STATE_UPDATE', 'PRESENCE_UPDATE', 'MESSAGE_DELETE', 'MESSAGE_UPDATE', 'CHANNEL_PINS_UPDATE', 'MESSAGE_REACTION_ADD', 'MESSAGE_REACTION_REMOVE', 'MESSAGE_REACTION_REMOVE_ALL', 'CHANNEL_PINS_UPDATE', 'MESSAGE_DELETE_BULK', 'WEBHOOKS_UPDATE'],
       owner: config.owner || '0',
       commandPrefix: config.commandPrefix || '!',
       unknownCommandResponse: false,

--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -39,7 +39,7 @@ class DiscordBot {
       messageCacheMaxSize: 0,
       retryLimit: 0,
       ws: {
-        intents: ["GUILD_MEMBERS", "GUILDS", "GUILD_MESSAGES"],
+        intents: ["GUILD_MEMBERS", "GUILDS", "GUILD_MESSAGES", "DIRECT_MESSAGES"],
       },
     })
 


### PR DESCRIPTION
This will allow certain commands like `help` to work in dms again. I also removed `disabledEvents` and `apiRequestMethod` as these are legacy client options and no longer exist.