### PR TITLE
Send patreon post link if bot is premium

### DIFF
--- a/src/commands/rover/InviteCommand.js
+++ b/src/commands/rover/InviteCommand.js
@@ -14,7 +14,7 @@ class InviteCommand extends Command {
   }
 
   async fn (msg) {
-    msg.author.send(`Use the following link to invite RoVer: <${config.invite}>`).then(() => {
+    msg.author.send(this.discordBot.isPremium() ? 'Visit https://www.patreon.com/posts/rover-plus-28480174 to invite RoVer Plus' : `Use the following link to invite RoVer: <${config.invite}>`).then(() => {
       msg.reply('Sent you a DM with information.')
     }).catch(() => {
       msg.reply('I can\'t seem to message you - please make sure your DMs are enabled!')

--- a/src/commands/rover/InviteCommand.js
+++ b/src/commands/rover/InviteCommand.js
@@ -14,7 +14,7 @@ class InviteCommand extends Command {
   }
 
   async fn (msg) {
-    msg.author.send(this.discordBot.isPremium() ? 'Visit https://www.patreon.com/posts/rover-plus-28480174 to invite RoVer Plus' : `Use the following link to invite RoVer: <${config.invite}>`).then(() => {
+    msg.author.send(this.discordBot.isPremium() ? 'Visit https://www.patreon.com/posts/rover-plus-28480174 to invite RoVer Plus' : `${config.invite ? `Use the following link to invite RoVer: <${config.invite}>` : 'Visit https://rover.link to invite RoVer'}`).then(() => {
       msg.reply('Sent you a DM with information.')
     }).catch(() => {
       msg.reply('I can\'t seem to message you - please make sure your DMs are enabled!')

--- a/src/commands/rover/InviteCommand.js
+++ b/src/commands/rover/InviteCommand.js
@@ -1,23 +1,35 @@
-const Command = require('../Command')
-const config = require('../../data/client.json')
+const Command = require("../Command");
+const config = require("../../data/client.json");
 
-module.exports =
-class InviteCommand extends Command {
-  constructor (client) {
+module.exports = class InviteCommand extends Command {
+  constructor(client) {
     super(client, {
-      name: 'invite',
-      properName: 'Invite',
-      aliases: ['roverinvite'],
-      description: 'Sends the user an invite link to invite RoVer.',
-      userPermissions: []
-    })
+      name: "invite",
+      properName: "Invite",
+      aliases: ["roverinvite"],
+      description: "Sends the user an invite link to invite RoVer.",
+      userPermissions: [],
+    });
   }
 
-  async fn (msg) {
-    msg.author.send(this.discordBot.isPremium() ? 'Visit https://www.patreon.com/posts/rover-plus-28480174 to invite RoVer Plus' : `${config.invite ? `Use the following link to invite RoVer: <${config.invite}>` : 'Visit https://rover.link to invite RoVer'}`).then(() => {
-      msg.reply('Sent you a DM with information.')
-    }).catch(() => {
-      msg.reply('I can\'t seem to message you - please make sure your DMs are enabled!')
-    })
+  async fn(msg) {
+    msg.author
+      .send(
+        this.discordBot.isPremium()
+          ? "Visit https://www.patreon.com/posts/rover-plus-28480174 to invite RoVer Plus"
+          : `${
+              config.invite
+                ? `Use the following link to invite RoVer: <${config.invite}>`
+                : "Visit https://rover.link to invite RoVer"
+            }`
+      )
+      .then(() => {
+        msg.reply("Sent you a DM with information.");
+      })
+      .catch(() => {
+        msg.reply(
+          "I can't seem to message you - please make sure your DMs are enabled!"
+        );
+      });
   }
-}
+};


### PR DESCRIPTION
Plus does not have an invite set which results in the dm looking like this

![image](https://user-images.githubusercontent.com/72576136/134355088-160133f7-2251-4986-b101-eac8e171e011.png)

Since plus doesn't have it set intentionally, we should send the patreon post link. Then if the bot is not premium but still doesn't have an invite set, we fall back to sending the website link.