### PR TITLE
Define Accolades

### DIFF
--- a/src/commands/rover/Subscription.js
+++ b/src/commands/rover/Subscription.js
@@ -1,4 +1,5 @@
 const Command = require("../Command")
+const Accolades = require("../../Accolades.json")
 
 module.exports = class SubscriptionCommand extends Command {
   constructor(client) {


### PR DESCRIPTION
We forgot to define Accolades in the subscriptions command, oops! This led the command to break like this. No worries it's fixed now :thinking_bacon:\
![image](https://user-images.githubusercontent.com/72576136/138276373-39fe15ee-9afc-4f81-90d6-24199f6917da.png)
