### PR TITLE
Don't delete "update" & "getroles" in #verify channel

### DIFF
--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -234,8 +234,14 @@ class DiscordBot {
     // If this is the verify channel, we want to delete the message and just verify the user if they aren't an admin.
     if (
       server.getSetting("verifyChannel") === message.channel.id &&
-      message.cleanContent.toLowerCase() !==
-        message.guild.commandPrefix + "verify" &&
+      (
+        message.cleanContent.toLowerCase() !==
+          message.guild.commandPrefix + "verify" ||
+        message.cleanContent.toLowerCase() !==
+          message.guild.commandPrefix + "update" ||
+        message.cleanContent.toLowerCase() !==
+          message.guild.commandPrefix + "getroles"
+      ) &&
       !(
         this.bot.isOwner(message.author) ||
         message.member.hasPermission("MANAGE_GUILD") ||


### PR DESCRIPTION
Currently, anything but `!verify` gets deleted. This PR allows `!update` and `!getroles` too.