### PR TITLE
Enforce limits on group id/rank length and notify users

### DIFF
--- a/src/commands/rover/BindGroupCommand.js
+++ b/src/commands/rover/BindGroupCommand.js
@@ -109,7 +109,8 @@ module.exports = class BindGroupCommand extends Command {
           const rankNumber = parseInt(rank, 10)
 
           if (
-            groupIsInt
+            isNaN(rank) ||
+            (groupIsInt
               ? rankNumber < 0 ||
                 rankNumber > 255 ||
                 (rangeMatch &&
@@ -117,7 +118,7 @@ module.exports = class BindGroupCommand extends Command {
                     rangeMatch[1] > 255 ||
                     rangeMatch[2] < 0 ||
                     rangeMatch[2] > 255))
-              : rank.length > 12
+              : rank.length > 12)
           ) {
             return msg.reply(
               ":no_entry_sign: You have attempted to bind an invalid rank/asset! Don't do that.",

--- a/src/commands/rover/BindGroupCommand.js
+++ b/src/commands/rover/BindGroupCommand.js
@@ -74,7 +74,7 @@ module.exports = class BindGroupCommand extends Command {
     for (const groupString of args.groups) {
       const [groupId, ranksString] = groupString.split(":")
       const group = { id: groupId }
-      const groupIsInt = !groudId.match(/[^\d]/)
+      const groupIsInt = !groupId.match(/[^\d]/)
 
       if (!groupIsInt && !VirtualGroups[groupId]) {
         return msg.reply(
@@ -107,6 +107,22 @@ module.exports = class BindGroupCommand extends Command {
         for (const rank of unparsedRanks) {
           const rangeMatch = rank.match(/(\d+)-(\d+)/)
           const rankNumber = parseInt(rank, 10)
+
+          if (
+            groupIsInt
+              ? rankNumber < 0 ||
+                rankNumber > 255 ||
+                (rangeMatch &&
+                  (rangeMatch[1] < 0 ||
+                    rangeMatch[1] > 255 ||
+                    rangeMatch[2] < 0 ||
+                    rangeMatch[2] > 255))
+              : rank.length > 12
+          ) {
+            return msg.reply(
+              ":no_entry_sign: You have attempted to bind an invalid rank/asset! Don't do that.",
+            )
+          }
 
           if (rangeMatch) {
             const start = parseInt(rangeMatch[1], 10)

--- a/src/commands/rover/BindGroupCommand.js
+++ b/src/commands/rover/BindGroupCommand.js
@@ -95,6 +95,11 @@ module.exports = class BindGroupCommand extends Command {
         }
       }
 
+      if (!groupId.match(/[^\d]/) && groupId.length > 9)
+        return msg.reply(
+          ":no_entry_sign: Sorry, but that group id is too long!",
+        )
+
       if (ranksString != null) {
         const ranks = []
         const unparsedRanks = ranksString.split(",")

--- a/src/commands/rover/BindGroupCommand.js
+++ b/src/commands/rover/BindGroupCommand.js
@@ -74,8 +74,9 @@ module.exports = class BindGroupCommand extends Command {
     for (const groupString of args.groups) {
       const [groupId, ranksString] = groupString.split(":")
       const group = { id: groupId }
+      const groupIsInt = !groudId.match(/[^\d]/)
 
-      if (groupId.match(/[^\d]/) && !VirtualGroups[groupId]) {
+      if (!groupIsInt && !VirtualGroups[groupId]) {
         return msg.reply(
           stripIndents`:no_entry_sign: You have attempted to bind an invalid group (\`${groupId}\`). Possible causes:
 
@@ -87,7 +88,7 @@ module.exports = class BindGroupCommand extends Command {
         )
       }
 
-      if (groupId.match(/[^\d]/) && groupId.toLowerCase() == "premium") {
+      if (!groupIsInt && groupId.toLowerCase() == "premium") {
         if (!config.cookie) {
           return msg.reply(
             oneLine`:no_entry_sign: Unfortunately, due to Roblox API changes, an authorization cookie needs to be set in the configuration for this VirtualGroup to work.`,
@@ -95,7 +96,7 @@ module.exports = class BindGroupCommand extends Command {
         }
       }
 
-      if (!groupId.match(/[^\d]/) && groupId.length > 9)
+      if (groupIsInt && groupId.length > 9)
         return msg.reply(
           ":no_entry_sign: Sorry, but that group id is too long!",
         )
@@ -121,7 +122,7 @@ module.exports = class BindGroupCommand extends Command {
           }
         }
         group.ranks = ranks
-      } else if (!groupId.match(/[a-z]/i)) {
+      } else if (groupIsInt) {
         group.ranks = []
         for (let i = 1; i <= 255; i++) {
           group.ranks.push(i)


### PR DESCRIPTION
As of now, users can specify completely invalid ranks/ids and they will be accepted with no complaint (which will end up not applying anyways - since they are invalid, and the user may end up not knowing why). We should reject those and notify users that they need to fix their input.

Example:
![image](https://user-images.githubusercontent.com/72576136/166862218-c3021e51-ea9f-4f4f-bf7d-389f8d01f334.png)